### PR TITLE
Switch training to search-distillation: add rollout-based search targets and replace actor-critic losses

### DIFF
--- a/experiments/run_full/run_new.py
+++ b/experiments/run_full/run_new.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
         total_vocab_tensor = words_to_tensor(total_vocab).to(device)                # [V, 5]
         model = DotGuessStateNet(model_cfg, total_vocab_tensor=total_vocab_tensor, device=device).to(device)
         ref_model = DotGuessStateNet(model_cfg, total_vocab_tensor=total_vocab_tensor, device=device).to(device).eval()
-        best_model = DotGuessStateNet(model_cfg, total_vocab_tensor=total_vocab_tensor, device=device).to(device).eval()
+        ref_model.load_state_dict(model.state_dict())
         # model_cfg = ActorCriticNetConfig(
         #     # state_input_dim = 292 = 26 letters * 11 letter possibilities (1 count, 5 green, 5 grey) + 6 (one-hot of guess number)
         #     hidden_dim=128 * c,
@@ -65,10 +65,6 @@ if __name__ == '__main__':
         # )
         # model = ActorCriticNet(model_cfg, device=device).to(device)
         # # model.load_state_dict(torch.load(f'{load_dir}/model.pth', map_location=device, weights_only=True))
-        # ref_model = ActorCriticNet(model_cfg, device=device).to(device).eval()
-        # best_model = ActorCriticNet(model_cfg, device=device).to(device).eval()
-        ref_model.load_state_dict(model.state_dict())
-        best_model.load_state_dict(model.state_dict())
 
         # Configs fed into trainer
         loader_cfg = WordleLoaderConfig(
@@ -81,24 +77,17 @@ if __name__ == '__main__':
         )
         simulator_cfg = SimulatorConfig(
             loader_cfg=loader_cfg,
-            gamma=1.0,
-            lam=1.0,
             max_guesses=6,
-            m=3,
-            advantage_type="gae",
-            adv_mean_reduce_dims=(2,),
-            adv_std_reduce_dims=(0, 2),
+            m=32,
+            num_search_actions=10,
         )
         loss_cfg = WordleLossConfig(
             loss_weights={
-                "actor": 5.0,
-                "critic": 5.0,
+                "search_kl": 1.0,
                 "entropy": 0.0,
-                "kl_reg": 1.00,
-                "kl_guide": 0.00,
-                "kl_best": 0.10,
-            },
-            ratio_prob_clip=0.2,
+                "kl_reg": 1.0,
+                "kl_guide": 0.25,
+            }
         )
         opt_handler_cfg = OptHandlerConfig(
             name="adamw",
@@ -133,7 +122,7 @@ if __name__ == '__main__':
             amp_dtype="bfloat16",
             rest_computer=0.0,
         )
-        trainer = Trainer(trainer_cfg, ref_model, model, best_model, device=device)
+        trainer = Trainer(trainer_cfg, ref_model, model, device=device)
     # Trainer from checkpoint
     else:
         ckpt_dir = Path(f"checkpoints/test/{args.resume_from}")

--- a/wordle/environment/simulator.py
+++ b/wordle/environment/simulator.py
@@ -2,7 +2,6 @@
 import math
 from tqdm import tqdm
 from typing import Union
-import warnings
 
 
 # Torch
@@ -22,14 +21,8 @@ class SimulatorConfig(Config):
             correct_reward: float = 0.1,
             correct_blend_factor: float = 1.0,
             max_guesses: int = 6,
-            gamma: float = 0.20,
-            lam: float = 0.95,
             m: int = 3,
-            reward_blend_factor: float = 1.0,
-            value_blend_factor: float = 1.0,
-            advantage_type: str = "reward-telescoped-value-baseline",
-            adv_mean_reduce_dims: Union[tuple, list, int, None] = (2,),
-            adv_std_reduce_dims: Union[tuple, list, int, None] = (0, 2),
+            num_search_actions: int = 10,
             fp_dtype: str = 'float32',
         ):
         self.loader_cfg = loader_cfg if loader_cfg is not None else WordleLoaderConfig()
@@ -38,38 +31,9 @@ class SimulatorConfig(Config):
         self.correct_reward = correct_reward
         self.correct_blend_factor = correct_blend_factor
         self.max_guesses = max_guesses
-        self.gamma = gamma
-        self.lam = lam
         self.m = m
-        self.reward_blend_factor = reward_blend_factor
-        self.value_blend_factor = value_blend_factor
-        self.advantage_type = self._as_advantage_type(advantage_type)
-        self.adv_mean_reduce_dims = self._as_reduce_dims(adv_mean_reduce_dims)
-        self.adv_std_reduce_dims = self._as_reduce_dims(adv_std_reduce_dims)
+        self.num_search_actions = num_search_actions
         self.fp_dtype = fp_dtype
-
-    def _as_advantage_type(self, advantage_type):
-        aliases = {
-            "reward-telecoped": "reward-telescoped",
-            "reward-telecoped-value-baseline": "reward-telescoped-value-baseline",
-        }
-        advantage_type = aliases.get(advantage_type, advantage_type)
-        valid = {
-            "gae",
-            "reward-total",
-            "reward-telescoped",
-            "reward-telescoped-value-baseline",
-        }
-        if advantage_type not in valid:
-            raise ValueError(f"Unknown advantage_type: {advantage_type}. Valid options are {sorted(valid)}")
-        return advantage_type
-
-    def _as_reduce_dims(self, reduce_dims):
-        if reduce_dims is None:
-            return None
-        if isinstance(reduce_dims, int):
-            return (reduce_dims,)
-        return tuple(reduce_dims)
 
 
 class Simulator:
@@ -85,14 +49,8 @@ class Simulator:
         self.correct_reward = self.cfg.correct_reward
         self.correct_blend_factor = self.cfg.correct_blend_factor
         self.max_guesses = self.cfg.max_guesses
-        self.gamma = self.cfg.gamma
-        self.lam = self.cfg.lam
         self.m = self.cfg.m
-        self.reward_blend_factor = self.cfg.reward_blend_factor
-        self.value_blend_factor = self.cfg.value_blend_factor
-        self.advantage_type = self.cfg.advantage_type
-        self.adv_mean_reduce_dims = self.cfg.adv_mean_reduce_dims
-        self.adv_std_reduce_dims = self.cfg.adv_std_reduce_dims
+        self.num_search_actions = self.cfg.num_search_actions
         self.fp_dtype = getattr(torch, self.cfg.fp_dtype)
         self.eps = 1e-8
 
@@ -296,74 +254,19 @@ class Simulator:
         idx[~enough] = torch.multinomial(mask_f[~enough], m, replacement=True)
         return idx
     
-    def _target_expansion(self, states, actions, m):
+    def step(self, model, data, states, actions, calculate_reward=True):
         """
-        Expand the states to have an additional dimension of size m for candidate target words.
-        """
-        idx = self._sample_targets(states["target_mask"])                                           # [B, m]
-        cand_data = self.loader._idx2data(idx)                                                      # dict with [B, m] batch idx for target and total
-        cand_states = {
-            "t": expand_var(states["t"], dim=-1, size=m),                                           # [B, *, m]
-            "alphabet": expand_var(states["alphabet"], dim=-3, size=m),                             # [B, *, m, 26, 11]
-            "active_mask": expand_var(states["active_mask"], dim=-1, size=m),                       # [B, *, m]
-            "guessed_mask": expand_var(states["guessed_mask"], dim=-2, size=m),                     # [B, *, m, V]
-            "target_mask": expand_var(states["target_mask"], dim=-2, size=m),                       # [B, *, m, T]
-            "total_target_mask": expand_var(states["total_target_mask"], dim=-2, size=m),           # [B, *, m, V]
-            "entropy": expand_var(states["entropy"], dim=-1, size=m),                               # [B, *, m]
-            "idx": idx,                                                                             # [B, *, m]
-        }
-        cand_actions = {
-            "policy_probs": expand_var(actions["policy_probs"], dim=-2, size=m),                    # [B, *, m, V]
-            "policy_probs_masked": expand_var(actions["policy_probs_masked"], dim=-2, size=m),      # [B, *, m, V]
-            "mixed_probs": expand_var(actions["mixed_probs"], dim=-2, size=m),                      # [B, *, m, V]
-            "mixed_probs_masked": expand_var(actions["mixed_probs_masked"], dim=-2, size=m),        # [B, *, m, V]
-            "guess_idx": expand_var(actions["guess_idx"], dim=-1, size=m),                          # [B, *, m]
-            "guess_mask": expand_var(actions["guess_mask"], dim=-2, size=m),                        # [B, *, m, V]
-            "valid_mask": expand_var(actions["valid_mask"], dim=-2, size=m),                        # [B, *, m, V]
-        }
-        return cand_data, cand_states, cand_actions
+        Simulate one Wordle step for the actual hidden target in ``data``.
 
-    def step(self, model, data, states, actions):
-        """
-        Simulate one Wordle step
-
-        Data:
-        - target:
-            - states: [T, 26, 11]
-            - tensor: [T, 5]
-        - total:
-            - states: [V, 26, 11]
-            - tensor: [V, 5]
-        
-        States:
-        - t: [B, *] (int)
-        - last_guess: [B, *] (bool)
-        - alphabet: [B, *, 26, 11]
-        - active_mask: [B, *]
-        - guessed_mask: [B, *, V]
-        - target_mask: [B, *, T]
-        - total_target_mask: [B, *, V]
-        - entropy: [B, *]
-
-        Returns:
-        - updated states
-        - responses:
-            - values: [B, *]
-            - rewards: [B, *]
-            - expected_values: [B, *]
-            - expected_rewards: [B, *]
-            - correct: [B, *]
+        This intentionally does not expand over sampled target candidates. Search
+        rollouts already expand states over [top-k actions, sampled hidden targets],
+        so doing another m-way expansion here would multiply memory by m again.
         """
         # Setup
         T = data["target"]["size"]
         V = data["total"]["size"]
 
-        # Simulate possible target words given the target mask
-        cand_data, cand_states, cand_actions = self._target_expansion(states, actions, self.m)
-        cand_data = move_to(cand_data, data["total"]["tensor"].device)
-        cand_states = move_to(cand_states, states["alphabet"].device)
-
-        # Update what we can in states before simulating response 
+        # Update what we can in states before simulating response
         # (t, alphabet, guessed_mask, active_mask)
         states["t"] = states["t"] + 1
         states["alphabet"] = self._update_alphabet(data, states, actions)           # [B, *, 26, 11]
@@ -371,26 +274,16 @@ class Simulator:
         states["guessed_mask"] = states["guessed_mask"] | F.one_hot(                # [B, *, V]
             actions["guess_idx"], num_classes=V
         ).bool()
-        cand_states["t"] = cand_states["t"] + 1
-        cand_states["alphabet"] = self._update_alphabet(                            # [B, *, m, 26, 11]
-            cand_data, cand_states, cand_actions
-        )
-        states["last_guess"] = (states["t"] == self.max_guesses)                    # [B, *]
-        cand_states["guessed_mask"] = cand_states["guessed_mask"] | F.one_hot(      # [B, *, m, V]
-            cand_actions["guess_idx"], num_classes=V
-        ).bool()
 
-        # Calculate responses
-        # NOTE: The model only requires updated t/alphabet for value estimates
-        with torch.no_grad():
-            _, values = model(states)                                               # [B, *]
-            _, cand_values = model(cand_states)                                     # [B, *, m]
+        # Calculate transition. Rewards are only needed for search rollouts; episode
+        # collection only needs the updated target mask and correctness for state
+        # progression/statistics.
         rewards, new_entropy, new_target_mask, correct = (                          # [B, *], [B, *], [B, *, T]
             self._calculate_rewards(data, states, actions)
         )
-        cand_rewards, _, _, _ = (                                                   # [B, *, m]
-            self._calculate_rewards(cand_data, cand_states, cand_actions)
-        )
+        if not calculate_reward:
+            rewards = torch.zeros_like(rewards)
+
         # NOTE: Right-padding requires the convention of targets first in the total vocab
         new_total_target_mask = F.pad(new_target_mask, (0, V - T)).bool()           # [B, *, V]
 
@@ -410,126 +303,128 @@ class Simulator:
 
         # Collect responses
         responses = {
-            "values": values,                                                       # [B, *]
             "rewards": rewards,                                                     # [B, *]
-            "expected_values": cand_values.mean(dim=-1),                            # [B, *]
-            "expected_rewards": cand_rewards.mean(dim=-1),                          # [B, *]
             "correct": correct                                                      # [B, *]
         }
 
         return states, responses
     
-    def _masked_mean(self, x, mask, reduce_dims):
-        if reduce_dims is None:
-            return torch.zeros((), dtype=x.dtype, device=x.device), None
-        count = mask.sum(dim=reduce_dims, keepdim=True)
-        mean = (x * mask).sum(dim=reduce_dims, keepdim=True) / count.clamp_min(1.0)
-        mean = torch.where(count > 0, mean, torch.zeros_like(mean))
-        return mean, count
-    
-    def _masked_std(self, x, mask, reduce_dims):
-        if reduce_dims is None:
-            return torch.ones((), dtype=x.dtype, device=x.device), None
-        mean, count = self._masked_mean(x, mask, reduce_dims)
-        ss_res = (((x - mean) * mask) ** 2).sum(dim=reduce_dims, keepdim=True)
-        std = torch.sqrt(ss_res / count.clamp_min(1.0)).clamp_min(self.eps)
-        std = torch.where(count > 0, std, torch.ones_like(std))
-        return std, count
-    
-    def norm_advantages(self, advantages, active_mask):                              # [B, G, R] (both)
-        adv_mean, mean_count = self._masked_mean(                                    # [*, *, *]
-            advantages, active_mask, self.adv_mean_reduce_dims
+    def _actions_from_guess_idx(self, base_actions, guess_idx):
+        # Rollout steps only need the selected word indices. Avoid expanding full
+        # probability tensors to [batch, repeats, top-k, m, vocab], which is the
+        # main avoidable OOM risk in search target construction.
+        V = base_actions["policy_probs"].shape[-1]
+        return {
+            "guess_idx": guess_idx,
+            "guess_mask": F.one_hot(guess_idx, num_classes=V).bool(),
+        }
+
+    def _sample_action_indices(self, probs, k):
+        """
+        Sample k proposed rollout actions from the policy distribution.
+
+        This is intentionally probabilistic rather than deterministic top-k:
+        high-probability actions are more likely to be searched, but lower-ranked
+        actions can still enter the rollout set.
+        """
+        *base_shape, V = probs.shape
+        flat_probs = probs.reshape(-1, V)
+        flat_idx = []
+        for row in flat_probs:
+            # Last-guess / <=2-candidate masks can leave fewer than k non-zero
+            # entries. Use replacement only for those degenerate rows; they are
+            # later overwritten by the normalized target-mask target anyway.
+            replacement = (row > 0).sum().item() < k
+            flat_idx.append(torch.multinomial(row, k, replacement=replacement))
+        return torch.stack(flat_idx, dim=0).reshape(*base_shape, k)
+
+    def _rollout_scores(self, model, data, states, base_actions, topk_idx, hidden_idx):
+        """
+        Score each proposed first action by averaging full-rollout reward over
+        uniformly sampled feasible hidden targets. Shapes are [B, K, M].
+        """
+        *base_shape, K = topk_idx.shape
+        M = hidden_idx.shape[-1]
+        device = states["t"].device
+        if tuple(states["t"].shape) != tuple(base_shape):
+            raise ValueError(f"Expected top-k base shape {tuple(states['t'].shape)}, got {tuple(base_shape)}")
+        if tuple(hidden_idx.shape[:-1]) != tuple(base_shape):
+            raise ValueError(f"Expected hidden sample base shape {tuple(base_shape)}, got {tuple(hidden_idx.shape[:-1])}")
+        rollout_states = {
+            "t": expand_var(expand_var(states["t"], -1, K), -1, M),
+            "last_guess": expand_var(expand_var(states["last_guess"], -1, K), -1, M),
+            "alphabet": expand_var(expand_var(states["alphabet"], -3, K), -3, M),
+            "active_mask": expand_var(expand_var(states["active_mask"], -1, K), -1, M),
+            "guessed_mask": expand_var(expand_var(states["guessed_mask"], -2, K), -2, M),
+            "target_mask": expand_var(expand_var(states["target_mask"], -2, K), -2, M),
+            "total_target_mask": expand_var(expand_var(states["total_target_mask"], -2, K), -2, M),
+            "entropy": expand_var(expand_var(states["entropy"], -1, K), -1, M),
+            "idx": expand_var(hidden_idx, -2, K),
+        }
+        rollout_data = self.loader._idx2data(rollout_states["idx"])
+        rollout_data = move_to(rollout_data, data["total"]["tensor"].device)
+        first_guess_idx = topk_idx.unsqueeze(-1).expand(*base_shape, K, M)
+        if tuple(first_guess_idx.shape) != (*base_shape, K, M):
+            raise ValueError(f"Unexpected first action expansion shape: {tuple(first_guess_idx.shape)}")
+        rollout_actions = self._actions_from_guess_idx(base_actions, first_guess_idx)
+
+        scores = torch.zeros((*base_shape, K, M), dtype=self.fp_dtype, device=device)
+        active_before = rollout_states["active_mask"].float()
+        rollout_states, responses = self.step(model, rollout_data, rollout_states, rollout_actions)
+        scores = scores + (responses["rewards"] * active_before)
+
+        for _ in range(self.max_guesses - 1):
+            if not rollout_states["active_mask"].any():
+                break
+            active_before = rollout_states["active_mask"].float()
+            rollout_actions = model.sample(rollout_states, alpha=0.0, temperature=1.0, argmax=True)
+            rollout_states, responses = self.step(model, rollout_data, rollout_states, rollout_actions)
+            scores = scores + (responses["rewards"] * active_before)
+        return scores.mean(dim=-1)
+
+    def search_actions(self, model, data, states, alpha, temperature, argmax=False):
+        """
+        Refine the model policy with policy-guided complete rollouts.
+
+        k model actions are sampled from the alpha/temperature-adjusted policy,
+        then scored against m uniformly sampled feasible hidden targets. Every
+        action after the proposed first action is chosen by a fully deterministic
+        argmax policy. Only the probability mass already assigned to the sampled
+        actions is redistributed according to rollout score; all non-selected
+        action probabilities are left unchanged. For states with <=2 feasible
+        targets, the normalized target mask is used directly as the target.
+        """
+        base_actions = model.sample(states, alpha, temperature, argmax=False)
+        probs = base_actions["policy_probs_masked"]
+        target_count = states["target_mask"].sum(dim=-1)
+        small_mask = target_count <= 2
+
+        k = min(self.num_search_actions, probs.shape[-1])
+        topk_idx = self._sample_action_indices(probs, k)
+        hidden_idx = self._sample_targets(states["target_mask"])
+        scores = self._rollout_scores(model, data, states, base_actions, topk_idx, hidden_idx)
+
+        search_probs = probs.clone()
+        selected_mass = probs.gather(-1, topk_idx).sum(dim=-1, keepdim=True)
+        topk_probs = F.softmax(scores, dim=-1) * selected_mass
+        search_probs.scatter_(-1, topk_idx, topk_probs)
+
+        target_probs = torch.where(
+            small_mask.unsqueeze(-1),
+            states["total_target_mask"].float() / states["total_target_mask"].float().sum(dim=-1, keepdim=True).clamp_min(self.eps),
+            search_probs,
         )
-        adv_std, std_count = self._masked_std(                                       # [*, *, *]
-            advantages, active_mask, self.adv_std_reduce_dims
-        )
+        target_probs = target_probs / target_probs.sum(dim=-1, keepdim=True).clamp_min(self.eps)
 
-        # Default normalization to 0/1 when there aren't enough active games
-        # NOTE: Skip zero active because then there's just no episode
-        min_adv_count = 2
-        if mean_count is not None:
-            mean_leq_min = (mean_count > 0) & (mean_count < min_adv_count)
-            if mean_leq_min.any():
-                warnings.warn(
-                    f"Mean advantage count is < {min_adv_count} for \
-                    {mean_leq_min.sum().item()} groups. Defaulting to 0 mean advantage."
-                )
-                adv_mean = torch.where(mean_leq_min, torch.zeros_like(adv_mean), adv_mean).detach()
-        if std_count is not None:
-            std_leq_min = (std_count > 0) & (std_count < min_adv_count)
-            if std_leq_min.any():
-                warnings.warn(
-                    f"Std advantage count is < {min_adv_count} for \
-                    {std_leq_min.sum().item()} groups. Defaulting to 1 std advantage."
-                )
-                adv_std = torch.where(std_leq_min, torch.ones_like(adv_std), adv_std).detach()
-
-        # Apply normalization
-        norm_advantages = ((advantages - adv_mean) / adv_std) * active_mask           # [B, G, R]
-        return norm_advantages, adv_mean, adv_std
-    
-    def calculate_advantages(self, responses, active_mask):
-        # Read
-        rewards = responses["rewards"]                      # [B, G, *]
-        values = responses["values"]                        # [B, G+1, *]
-        expected_rewards = responses["expected_rewards"]    # [B, G, *]
-        expected_values = responses["expected_values"]      # [B, G, *]
-        active = active_mask[:, :-1, ...].float()           # [B, G, *]
-        next_active = active_mask[:, 1:, ...].float()       # [B, G, *]
-        
-        # Setup
-        B, _, *dims = active_mask.shape
-        G = self.max_guesses
-        device = rewards.device
-
-        # Blend and mask the tensors
-        # NOTE: Important for advantages to not be influenced by values/rewards after an episode finishes!
-        blended_rewards = (                                                             # [B, G, *]
-            self.reward_blend_factor * expected_rewards +
-            (1 - self.reward_blend_factor) * rewards
-        ) * active
-        blended_next_values = (                                                         # [B, G, *]
-            self.value_blend_factor * expected_values +
-            (1 - self.value_blend_factor) * values[:, 1:, ...]
-        ).detach() * next_active
-        current_values = (values[:, :-1, ...] * active).detach()                        # [B, G, *]
-
-        # Compute returns and advantages
-        if self.advantage_type == "gae":
-            advantages = torch.zeros((B, G, *dims), dtype=self.fp_dtype, device=device)
-            gae = torch.zeros((B, *dims), dtype=self.fp_dtype, device=device)
-            for t in reversed(range(G)):
-                delta = (
-                    blended_rewards[:, t, ...] +
-                    self.gamma * blended_next_values[:, t, ...] -
-                    current_values[:, t, ...]
-                )
-                gae = delta + self.gamma * self.lam * next_active[:, t, ...] * gae
-                advantages[:, t, ...] = gae
-            advantages = advantages * active
-            returns = (advantages + current_values) * active
-        elif self.advantage_type == "reward-total":
-            returns = blended_rewards.sum(dim=1, keepdim=True).expand(B, G, *dims) * active
-            advantages = returns
-        elif self.advantage_type in {"reward-telescoped", "reward-telescoped-value-baseline"}:
-            returns = torch.zeros((B, G, *dims), dtype=self.fp_dtype, device=device)
-            running_return = torch.zeros((B, *dims), dtype=self.fp_dtype, device=device)
-            for t in reversed(range(G)):
-                running_return = blended_rewards[:, t, ...] + self.gamma * running_return
-                returns[:, t, ...] = running_return
-            returns = returns * active
-            if self.advantage_type == "reward-telescoped-value-baseline":
-                advantages = (returns - current_values) * active
-            else:
-                advantages = returns
+        if argmax:
+            guess_idx = target_probs.argmax(dim=-1)
         else:
-            raise ValueError(f"Unknown advantage_type: {self.advantage_type}")
-
-        norm_advantages, adv_mean, adv_std = self.norm_advantages(advantages, active)
-        responses["returns"] = returns.detach()                                             # [B, G, *]
-        responses["advantages"] = advantages.detach()                                       # [B, G, *]
-        responses["norm_advantages"] = norm_advantages                                      # [B, G, *]
-        return responses
+            *dims, V = target_probs.shape
+            guess_idx = torch.multinomial(target_probs.reshape(-1, V), 1).squeeze(-1).reshape(*dims)
+        base_actions["guess_idx"] = guess_idx
+        base_actions["guess_mask"] = F.one_hot(guess_idx, num_classes=target_probs.shape[-1]).bool()
+        base_actions["search_target_probs"] = target_probs
+        return base_actions
     
     def collect_episodes_mb(self, model, data, alpha, temperature, argmax=False):
         """We keep the entire episodes on CPU, then states, actions, responses on Model device"""
@@ -554,11 +449,12 @@ class Simulator:
             #       the episodes after collecting.
             # while (states["t"] <= G).all() and states["active_mask"].any():
             for t in range(1, G+1):
-                # Select actions = f(states)
+                # Select collection actions directly from the model. Search targets are built later
+                # when processing the collected states for training/evaluation loss.
                 actions = model.sample(states, alpha, temperature, argmax=argmax)
 
                 # Simulate responses = f(states, actions)
-                states, responses = self.step(model, data, states, actions)
+                states, responses = self.step(model, data, states, actions, calculate_reward=False)
 
                 # Store
                 self._append_dict(episodes["states"], move_to(states, "cpu"))
@@ -589,11 +485,48 @@ class Simulator:
         episodes["actions"] = self._cat_dict(episodes["actions"], dim=0)
         episodes["responses"] = self._cat_dict(episodes["responses"], dim=0)    
 
-        # Calculate advantages
-        episodes["responses"] = self.calculate_advantages(
-            episodes["responses"], episodes["states"]["active_mask"]
-        )    
         return episodes
+
+    def _slice_states_at_turn(self, states, turn):
+        return {k: v[:, turn, ...] if isinstance(v, torch.Tensor) else v for k, v in states.items()}
+
+    def build_search_targets_for_states(self, model, states, alpha, temperature):
+        """Build search-distillation targets for already-collected episode states."""
+        targets = []
+        G = self.max_guesses
+        with torch.no_grad():
+            for turn in range(G):
+                turn_states = self._slice_states_at_turn(states, turn)
+                turn_data = self.loader._idx2data(turn_states["idx"])
+                turn_data = move_to(turn_data, turn_states["t"].device)
+                search_actions = self.search_actions(
+                    model,
+                    turn_data,
+                    turn_states,
+                    alpha,
+                    temperature,
+                    argmax=True,
+                )
+                targets.append(search_actions["search_target_probs"])
+        return torch.stack(targets, dim=1)
+
+    def unique_state_pct(self, states):
+        """Return percentage of active inference states that are unique.
+
+        States are keyed by turn index plus feasible target mask. This approximates
+        how often inference/search revisits the same belief state and whether a
+        tree/cache structure could reuse work.
+        """
+        active = states["active_mask"][:, :-1, ...].bool()
+        if not active.any():
+            return torch.zeros((), dtype=self.fp_dtype, device=active.device)
+
+        target_mask = states["target_mask"][:, :-1, ...][active].to(torch.uint8)
+        turns = states["t"][:, :-1, ...][active].to(torch.uint8).unsqueeze(-1)
+        state_keys = torch.cat((turns, target_mask), dim=-1)
+        unique_count = torch.unique(state_keys, dim=0).shape[0]
+        total_count = state_keys.shape[0]
+        return torch.tensor(100.0 * unique_count / total_count, dtype=self.fp_dtype, device=active.device)
 
     def process_episodes(
         self,
@@ -622,4 +555,8 @@ class Simulator:
 
         # Collect new responses
         responses["pred_values"] = (pred_values * active_mask.float())[:, :-1, ...]     # [B, G+1, *]                                               # [B, G, *]
+        responses["search_target_probs"] = self.build_search_targets_for_states(
+            model, states, alpha, temperature
+        )
+        responses["unique_state_pct"] = self.unique_state_pct(states)
         return probs, responses

--- a/wordle/train/inference.py
+++ b/wordle/train/inference.py
@@ -139,10 +139,9 @@ def inference(model, target_idx):
     )
     simulator_cfg = SimulatorConfig(
         loader_cfg=loader_cfg,
-        gamma=0.2,
-        lam=0.95,
         max_guesses=6,
         m=1,
+        num_search_actions=10,
     )
     simulator = Simulator(simulator_cfg)
 
@@ -154,8 +153,7 @@ def inference(model, target_idx):
         data,
         alpha=0.0,
         temperature=1.0,
-        argmax=True,
-        desc="Collecting Eval Episodes"
+        argmax=True
     )
     return episodes
 

--- a/wordle/train/loss.py
+++ b/wordle/train/loss.py
@@ -1,325 +1,121 @@
-# General
-from typing import Tuple, List
+from typing import Tuple
 
-# Torch
 import torch
 import torch.nn.functional as F
 
-# Wordle
 from wordle.utils import Config, to_float
 
 
-
 class EnumLossComponent:
-    ACTOR = "actor"
-    CRITIC = "critic"
+    SEARCH_KL = "search_kl"
     ENTROPY = "entropy"
     KL_REG = "kl_reg"
     KL_GUIDE = "kl_guide"
-    KL_BEST = "kl_best"
+    SEARCH_COSINE = "search_cosine"
+    UNIQUE_STATE_PCT = "unique_state_pct"
 
 
 class WordleLossConfig(Config):
     def __init__(
             self,
             loss_weights: dict = None,
-            ratio_prob_clip: float = 0.2,
-            min_prob_clip: float = -0.01,
-            max_prob_clip: float = 0.95,
             eps: float = 1e-12,
-            clamp: float = 1e-12
+            clamp: float = 1e-12,
     ):
         self.loss_weights = loss_weights if loss_weights is not None else self.default_weights()
-        self.ratio_prob_clip = ratio_prob_clip
-        self.min_prob_clip = min_prob_clip
-        self.max_prob_clip = max_prob_clip
         self.eps = eps
         self.clamp = clamp
 
     def default_weights(self):
-        loss_weights = {
-            EnumLossComponent.ACTOR: 1.0,
-            EnumLossComponent.CRITIC: 5.0,
-            EnumLossComponent.ENTROPY: 0.00,
+        return {
+            EnumLossComponent.SEARCH_KL: 1.0,
+            EnumLossComponent.ENTROPY: 0.0,
             EnumLossComponent.KL_REG: 1.0,
             EnumLossComponent.KL_GUIDE: 0.25,
-            EnumLossComponent.KL_BEST: 0.10,
         }
-        return loss_weights
 
 
 class WordleLoss:
     def __init__(self, cfg: WordleLossConfig):
-        # Read
         self.cfg = cfg
-        self.ratio_prob_clip = self.cfg.ratio_prob_clip
-        self.min_prob_clip = self.cfg.min_prob_clip
-        self.max_prob_clip = self.cfg.max_prob_clip
         self.eps = self.cfg.eps
         self.clamp = self.cfg.clamp
-        # Init objects
         self.init_cumulative_loss()
-    
-    def log_normalize(self, probs):     # [B, *, V]
-        probs = probs + self.eps        # Avoid log(0)
-        probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(self.clamp)  # Normalize
+
+    def log_normalize(self, probs):
+        probs = probs + self.eps
+        probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(self.clamp)
         return torch.log(probs)
 
-    def clip_grad_range(self, probs):
-        # NOTE: It is sometimes beneficialy to clip grads so that the model can focus
-        # on learning new things rather than doubling down on one successful motif.
-        keep = (((probs >= self.min_prob_clip) & (probs <= self.max_prob_clip)).float())
-        return probs * keep + (1 - keep) * probs.detach()
-    
-    def clip_prob_ratio(self, ratio):
-        keep = (((ratio >= 1 - self.ratio_prob_clip) & (ratio <= 1 + self.ratio_prob_clip)).float())
-        return ratio * keep + (1 - keep) * ratio.detach()
-    
-    # def group_norm_advantages(self, advantages, active_mask):                   # [B, G, R] (both)
-    #     # Calculate stats only over active games
-    #     masked_advantages = advantages * active_mask                            # [B, G, R]
-    #     sum_adv = masked_advantages.sum(dim=2, keepdim=True)                    # [B, G, 1]
-    #     num_active = active_mask.sum(dim=2, keepdim=True).clamp_min(self.eps)   # [B, G, 1]
-    #     mean_adv = (sum_adv / num_active)                                       # [B, G, 1]
-    #     diff_adv = (advantages - mean_adv) * active_mask
-    #     sum_square_adv = (diff_adv.pow(2)).sum(dim=2, keepdim=True)
-    #     std_adv = (sum_square_adv / num_active).sqrt().clamp_min(self.eps)
-    #     # Only apply normalization when there are enough active games
-    #     # (otherwise, std would be 0 and cause problems)
-    #     zero = torch.zeros_like(mean_adv)
-    #     one = torch.ones_like(std_adv)
-    #     mean_adv = torch.where(num_active <= 1, zero, mean_adv).detach()  # skip mean normalization when not enough active games
-    #     std_adv = torch.where(num_active <= 1, one, std_adv).detach()  # default to 1.0 std when not enough active games
-    #     # advantages = (advantages - mean_adv) / std_adv
-    #     advantages = (advantages - mean_adv)
-    #     advantages_active = advantages[active_mask]
-    #     return advantages_active
-
-    # def custom_norm_advantages(self, advantages, active_mask):                          # [B, G, R] (both)
-    #     # Calculate stats only over active games
-    #     masked_advantages = advantages * active_mask                                    # [B, G, R]
-
-    #     # Norm baseline is per group
-    #     adv_sum = masked_advantages.sum(dim=2, keepdim=True)                            # [B, G, 1]
-    #     adv_mean_count = active_mask.sum(dim=2, keepdim=True).clamp_min(1.0)            # [B, G, 1]
-    #     adv_mean = (adv_sum / adv_mean_count)                                           # [B, G, 1]
-
-    #     # Std adv is global to not bias towards any hidden state or timestep
-    #     adv_diff = (advantages - adv_mean) * active_mask                                # [B, G, R]
-    #     adv_sum_square = (adv_diff.pow(2)).sum(dim=[0, 1, 2], keepdim=True)             # [1, 1, 1]
-    #     adv_std_count = active_mask.sum(dim=[0, 1, 2], keepdim=True).clamp_min(1.0)     # [1, 1, 1]
-    #     adv_std = (adv_sum_square / adv_std_count).sqrt().clamp_min(self.eps)           # [1, 1, 1]
-    #     # Only apply normalization when there are enough active games
-    #     # (otherwise, std would be 0 and cause problems)
-    #     zero = torch.zeros_like(adv_mean)
-    #     one = torch.ones_like(adv_std)
-    #     mean_adv = torch.where(adv_mean_count <= 1, zero, adv_mean).detach()            # skip mean normalization when not enough active games
-    #     std_adv = torch.where(adv_std_count <= 1, one, adv_std).detach()                # default to 1.0 std when not enough active games
-    #     advantages = (advantages - mean_adv) / std_adv
-    #     advantages_active = advantages[active_mask]
-    #     return advantages_active
-    
     def make_loss(self):
-        loss = 0.0
-        loss_components = {
-            EnumLossComponent.ACTOR: 0.0,
-            EnumLossComponent.CRITIC: 0.0,
+        return 0.0, {
+            EnumLossComponent.SEARCH_KL: 0.0,
             EnumLossComponent.ENTROPY: 0.0,
             EnumLossComponent.KL_REG: 0.0,
             EnumLossComponent.KL_GUIDE: 0.0,
-            EnumLossComponent.KL_BEST: 0.0
+            EnumLossComponent.SEARCH_COSINE: 0.0,
+            EnumLossComponent.UNIQUE_STATE_PCT: 0.0,
         }
-        return loss, loss_components
-    
+
     def init_cumulative_loss(self):
         self.loss, self.loss_components = self.make_loss()
 
-    def measure_grad_norms(
-            self, model, states, actions, responses, 
-            probs, ref_probs, best_probs
-        ) -> Tuple[float, float, float, float, float, float]:
-        # """
-        # Run backward passes to measure the gradient-norm of:
-        #     1) actor_coef * actor_loss
-        #     2) critic_coef * critic_loss
-        #     3) entropy_coef * entropy_loss
-        #     4) kl_reg_coef * kl_reg_loss
-        #     5) kl_guide_coef * kl_guide_loss
-        #     6) kl_best_coef * kl_best_loss
-        # """
-
-        # # Define helper
-        # def _mean_grad_norm(scaled_loss: torch.Tensor) -> float:
-        #     grads: List[torch.Tensor] = torch.autograd.grad(
-        #         scaled_loss,
-        #         [p for p in model.parameters() if p.requires_grad],
-        #         retain_graph=True,       # keep the graph alive for the upcoming backward
-        #         create_graph=False,
-        #         allow_unused=True,
-        #     )
-        #     grads = [g for g in grads if g is not None]
-        #     if not grads:                     # safeguard (shouldn’t happen)
-        #         return 0.0
-        #     return torch.stack([g.norm() for g in grads]).mean().item()
-        # # -----------------------------------------------------------------
-
-        # # Calculate
-        # actor_norm = critic_norm = entropy_norm = kl_reg_norm = kl_guide_norm = kl_best_norm = 0.0
-        # actor_norm = _mean_grad_norm(
-        #     self.cfg.loss_weights[EnumLossComponent.ACTOR] * 
-        #     self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)[0]
-        # ) if self.cfg.loss_weights[EnumLossComponent.ACTOR] != 0.0 else 0.0
-        # critic_norm = _mean_grad_norm(
-        #     self.cfg.loss_weights[EnumLossComponent.CRITIC] * 
-        #     self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)[1]
-        # ) if self.cfg.loss_weights[EnumLossComponent.CRITIC] != 0.0 else 0.0
-        # entropy_norm = _mean_grad_norm(
-        #     self.cfg.loss_weights[EnumLossComponent.ENTROPY] * 
-        #     self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)[2]
-        # ) if self.cfg.loss_weights[EnumLossComponent.ENTROPY] != 0.0 else 0.0
-        # kl_reg_norm = _mean_grad_norm(
-        #     self.cfg.loss_weights[EnumLossComponent.KL_REG] * 
-        #     self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)[3]
-        # ) if self.cfg.loss_weights[EnumLossComponent.KL_REG] != 0.0 else 0.0
-        # kl_guide_norm = _mean_grad_norm(
-        #     self.cfg.loss_weights[EnumLossComponent.KL_GUIDE] * 
-        #     self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)[4]
-        # ) if self.cfg.loss_weights[EnumLossComponent.KL_GUIDE] != 0.0 else 0.0
-        # kl_best_norm = _mean_grad_norm(
-        #     self.cfg.loss_weights[EnumLossComponent.KL_BEST] * 
-        #     self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)[5]
-        # ) if self.cfg.loss_weights[EnumLossComponent.KL_BEST] != 0.0 else 0.0
-
-        # # Show
-        # print(
-        #     f"[Grad Norms] Actor: {actor_norm:.6f} | Critic: {critic_norm:.6f} | "
-        #     f"Entropy: {entropy_norm:.6f} | KL Reg: {kl_reg_norm:.6f} | "
-        #     f"KL Guide: {kl_guide_norm:.6f} | KL Best: {kl_best_norm:.6f}"
-        # )
+    def measure_grad_norms(self, *args, **kwargs):
         print("Skip grad norms for now")
 
-    def calculate_loss_components(self, states, actions, responses, probs, ref_probs, best_probs) -> Tuple[torch.Tensor, dict]:
-        # Unpack
-        active_mask = states["active_mask"][:, :-1, ...]                # [B, G+1, *] --> [B, G, *]
-        ref_policy_probs = ref_probs["policy_probs"][:, :-1, ...]              # [B, G, *, V]
-        ref_mixed_masked_probs = ref_probs["mixed_probs_masked"][:, :-1, ...]   # [B, G, *, V]
-        valid_mask = actions["valid_mask"]                              # [B, G, V]
-        guess_mask = actions["guess_mask"]                              # [B, G, V]
-        policy_probs = probs["policy_probs"]                            # [B, G, *, V]
-        masked_probs = probs["policy_probs_masked"]                     # [B, G, *, V]
-        mixed_masked_probs = probs["mixed_probs_masked"]                # [B, G, *, V]
-        best_policy_probs = best_probs["policy_probs"][:, :-1, ...]            # [B, G, *, V]
-        best_mixed_masked_probs = best_probs["mixed_probs_masked"][:, :-1, ...]     # [B, G, *, V]
-        advantages = responses["advantages"]                            # [B, G, *]
-        norm_advantages = responses["norm_advantages"]          # [B, G, *]
+    def calculate_loss_components(self, states, actions, responses, probs, ref_probs=None) -> Tuple[torch.Tensor, ...]:
+        active_mask = states["active_mask"][:, :-1, ...]
+        target_probs = responses["search_target_probs"].detach()
+        valid_mask = actions["valid_mask"]
+        policy_probs = probs["policy_probs"]
+        policy_probs_masked = probs["policy_probs_masked"]
 
-        # Freeze gradient for probs outside threshold
-        # (can prevent kl-guide from getting too much of the gradient to go all the way to 0 or 1)
-        range_clipped_probs = self.clip_grad_range(policy_probs)
+        target_active = target_probs[active_mask]
+        policy_active = policy_probs[active_mask]
+        masked_active = policy_probs_masked[active_mask]
+        valid_active = valid_mask[active_mask]
+        log_policy_active = self.log_normalize(policy_active)
+        log_masked_active = self.log_normalize(masked_active)
 
-        # Mask for only active turns
-        ref_probs_active = ref_policy_probs[active_mask]
-        ref_mixed_masked_probs_active = ref_mixed_masked_probs[active_mask]
-        probs_active = policy_probs[active_mask]
-        range_clipped_probs_active = range_clipped_probs[active_mask]
-        masked_probs_active = masked_probs[active_mask]
-        mixed_masked_probs_active = mixed_masked_probs[active_mask]
-        best_probs_active = best_policy_probs[active_mask]
-        best_mixed_masked_probs_active = best_mixed_masked_probs[active_mask]
-        advantages_active = advantages[active_mask]
-        norm_advantages_active = norm_advantages[active_mask]
+        # Main search-distillation objective: KL(target_search || masked model policy).
+        search_kl = F.kl_div(log_masked_active, target_active, reduction="batchmean", log_target=False)
 
-        # Prob distribution log terms
-        ref_log_probs_active = self.log_normalize(ref_probs_active)
-        ref_mixed_masked_log_probs_active = self.log_normalize(ref_mixed_masked_probs_active)
-        log_probs_active = self.log_normalize(probs_active)
-        clipped_log_probs_active = self.log_normalize(range_clipped_probs_active)
-        masked_log_probs_active = self.log_normalize(masked_probs_active)
-        mixed_masked_log_probs_active = self.log_normalize(mixed_masked_probs_active)
-        best_log_probs_active = self.log_normalize(best_probs_active)
-        best_mixed_masked_log_probs_active = self.log_normalize(best_mixed_masked_probs_active)
+        # Entropy regularization over valid actions only. Minimizing negative entropy maximizes entropy.
+        entropy_probs = policy_active * valid_active.float()
+        entropy_probs = entropy_probs / entropy_probs.sum(dim=-1, keepdim=True).clamp_min(self.clamp)
+        entropy_loss = torch.sum(entropy_probs * self.log_normalize(entropy_probs), dim=-1).mean()
 
-        # # Entropy regularization
-        # entropy_probs = policy_probs * valid_mask  # should not include the probabilities which we deem invalid
-        # entropy_probs = entropy_probs / entropy_probs.sum(dim=-1, keepdim=True).clamp_min(self.eps)
-        # entropy_log_probs = self.log_normalize(entropy_probs)
-        # entropies = -torch.sum(entropy_probs * entropy_log_probs, dim=-1)
-        # entropies_active = entropies[active_mask]
+        if ref_probs is not None:
+            ref_active = ref_probs["policy_probs"][:, :-1, ...][active_mask].detach()
+            kl_reg_loss = F.kl_div(log_policy_active, ref_active, reduction="batchmean", log_target=False)
+        else:
+            kl_reg_loss = torch.zeros((), dtype=policy_active.dtype, device=policy_active.device)
 
-        # Prob ratio of chosen actions for the actor loss
-        active_guess_mask = guess_mask[active_mask]
-        # chosen_ref_log_probs = ref_log_probs_active[active_guess_mask]
-        chosen_ref_log_probs = ref_mixed_masked_log_probs_active[active_guess_mask]
-        # chosen_log_probs = log_probs_active[active_guess_mask]
-        chosen_log_probs = mixed_masked_log_probs_active[active_guess_mask]
-        prob_ratio = torch.exp(chosen_log_probs - chosen_ref_log_probs)
-        clipped = torch.clamp(prob_ratio, 1 - self.ratio_prob_clip, 1 + self.ratio_prob_clip)
+        # Guide the raw policy toward its valid-action-masked version so inductive-bias masking
+        # becomes less necessary over time.
+        kl_guide_loss = F.kl_div(log_policy_active, masked_active.detach(), reduction="batchmean", log_target=False)
+        search_cosine = F.cosine_similarity(masked_active.detach(), target_active.detach(), dim=-1).mean()
+        return (search_kl, entropy_loss, kl_reg_loss, kl_guide_loss, search_cosine)
 
-        # Get normalized advantages by group
-        # NOTE: Detach advantage grad for actor loss because that would 
-        #       train the critic to change the advantages for actor loss!
-        # detached_advantages = advantages.clone().detach()
-        # policy_advantages_active = self.custom_norm_advantages(detached_advantages, active_mask)
-        policy_advantages_active = norm_advantages_active.clone().detach()
-
-        # Critic loss is computed with the advantages before normalization
-        pred_values = responses["pred_values"]
-        critic_losses = (responses["returns"] - pred_values)[active_mask].pow(2)
-        # critic_losses = advantages_active.pow(2)
-
-        # Actor loss
-        surr1 = prob_ratio * policy_advantages_active
-        surr2 = clipped * policy_advantages_active
-        actor_loss = -torch.min(surr1, surr2).mean()
-        # Critic loss
-        critic_loss = critic_losses.mean()
-        # critic_loss = 0.0
-        # Entropy loss
-        # entropy_loss = -entropies_active.mean()
-        entropy_loss = 0.0
-        # KL-Div losses
-        ## NOTE: Of the form F.kl_div(input, target) = KL(target || input) = mean(sum(target * (log(target) - log(input)), dim=-1))
-        kl_reg_loss = F.kl_div(
-            ref_log_probs_active, log_probs_active, reduction='batchmean', log_target=True
-        )
-        kl_guide_loss = F.kl_div(
-            masked_log_probs_active.detach(), clipped_log_probs_active, reduction='batchmean', log_target=True
-        )
-        kl_best_loss = F.kl_div(
-            best_log_probs_active, log_probs_active, reduction='batchmean', log_target=True
-        )
-        return (actor_loss, critic_loss, entropy_loss, kl_reg_loss, kl_guide_loss, kl_best_loss)
-
-    def inc_loss(self, states, actions, responses, probs, ref_probs, best_probs):
-        """
-        This function starts with a lot of setup to create the various objects 
-        needed for calculating the loss components.
-        """
-        # Setup
+    def inc_loss(self, states, actions, responses, probs, ref_probs=None):
         batch_loss, batch_loss_components = self.make_loss()
-        losses = self.calculate_loss_components(states, actions, responses, probs, ref_probs, best_probs)
+        losses = self.calculate_loss_components(states, actions, responses, probs, ref_probs)
+        loss_keys = [
+            EnumLossComponent.SEARCH_KL,
+            EnumLossComponent.ENTROPY,
+            EnumLossComponent.KL_REG,
+            EnumLossComponent.KL_GUIDE,
+        ]
+        for key, loss in zip(loss_keys, losses[:len(loss_keys)]):
+            batch_loss_components[key] = to_float(loss)
+            batch_loss = batch_loss + self.cfg.loss_weights.get(key, 0.0) * loss
+        batch_loss_components[EnumLossComponent.SEARCH_COSINE] = to_float(losses[-1])
+        if "unique_state_pct" in responses:
+            batch_loss_components[EnumLossComponent.UNIQUE_STATE_PCT] = to_float(responses["unique_state_pct"])
 
-        # Calculate loss components
-        batch_loss_components[EnumLossComponent.ACTOR] = to_float(losses[0])
-        batch_loss_components[EnumLossComponent.CRITIC] = to_float(losses[1])
-        batch_loss_components[EnumLossComponent.ENTROPY] = to_float(losses[2])
-        batch_loss_components[EnumLossComponent.KL_REG] = to_float(losses[3])
-        batch_loss_components[EnumLossComponent.KL_GUIDE] = to_float(losses[4])
-        batch_loss_components[EnumLossComponent.KL_BEST] = to_float(losses[5])
-        # Total loss
-        batch_loss = (
-            self.cfg.loss_weights[EnumLossComponent.ACTOR] * losses[0] +
-            self.cfg.loss_weights[EnumLossComponent.CRITIC] * losses[1] +
-            self.cfg.loss_weights[EnumLossComponent.ENTROPY] * losses[2] +
-            self.cfg.loss_weights[EnumLossComponent.KL_REG] * losses[3] +
-            self.cfg.loss_weights[EnumLossComponent.KL_GUIDE] * losses[4] +
-            self.cfg.loss_weights[EnumLossComponent.KL_BEST] * losses[5]
-        )
-
-        # Inc metrics (with coefficients for total_loss)
         self.loss = self.loss + batch_loss.item()
-        for k in self.loss_components.keys():
-            self.loss_components[k] = self.loss_components[k] + batch_loss_components[k]
+        for key in self.loss_components:
+            self.loss_components[key] += batch_loss_components[key]
         return batch_loss, batch_loss_components
 
     def average_cumulative_loss(self, num_batches):

--- a/wordle/train/scheduler.py
+++ b/wordle/train/scheduler.py
@@ -52,8 +52,7 @@ class Scheduler:
         self.alpha = self.init_alpha
         self.temperature = self.init_temperature
         self.best_metrics = {
-            "actor_loss": float('inf'),
-            "critic_loss": float('inf'),
+            "search_kl": float('inf'),
             "win_rate": 0.0,
             "avg_guesses": float('inf')
         }
@@ -103,11 +102,8 @@ class Scheduler:
         if avg_guesses < self.best_metrics["avg_guesses"]:
             self.best_metrics["avg_guesses"] = to_float(avg_guesses)
             no_improvement = False
-        if loss_components["actor"] < self.best_metrics["actor_loss"]:
-            self.best_metrics["actor_loss"] = to_float(loss_components["actor"])
-            no_improvement = False
-        if loss_components["critic"] < self.best_metrics["critic_loss"]:
-            self.best_metrics["critic_loss"] = to_float(loss_components["critic"])
+        if loss_components["search_kl"] < self.best_metrics["search_kl"]:
+            self.best_metrics["search_kl"] = to_float(loss_components["search_kl"])
             no_improvement = False
 
         # Update patience counter
@@ -131,8 +127,7 @@ class Scheduler:
                     print(f'  -> Evolved temperature: {self.temperature:.2f} -> {new_temperature:.2f}, alpha: {self.alpha:.2f} -> {self.alpha:.2f}')
                     self.temperature = new_temperature
                 self.steps_since_improvement = 0
-                self.best_metrics["actor_loss"] = float('inf')
-                self.best_metrics["critic_loss"] = float('inf')
+                self.best_metrics["search_kl"] = float('inf')
 
     def state_dict(self):
         return {

--- a/wordle/train/trainer.py
+++ b/wordle/train/trainer.py
@@ -86,12 +86,11 @@ class TrainerConfig(Config):
 
 
 class Trainer:
-    def __init__(self, cfg, ref_model, model, best_model, device: Union[str, torch.device] = "cpu") -> None:
+    def __init__(self, cfg, ref_model, model, device: Union[str, torch.device] = "cpu") -> None:
         # Read vars
         self.cfg = cfg
         self.ref_model = ref_model.to(device).eval()
         self.model = model.to(device)
-        self.best_model = best_model.to(device).eval()
         self.device = device
         self.fp_dtype = getattr(torch, self.cfg.fp_dtype)
         self.amp_dtype = None if self.cfg.amp_dtype in {None, "none"} else getattr(torch, self.cfg.amp_dtype)
@@ -117,7 +116,7 @@ class Trainer:
     overwriting something after loading from checkpoint.
     """
     def __reinit__(self):
-        self.__init__(self.cfg, self.ref_model, self.model, self.best_model, self.device)
+        self.__init__(self.cfg, self.ref_model, self.model, self.device)
 
     def state_dict(self):
         return {
@@ -160,13 +159,11 @@ class Trainer:
         self.scheduler.cfg.save(save_dir / "scheduler_config.json")
         self.logger.cfg.save(save_dir / "logger_config.json")
 
-        # Save models (ref, current, best)
+        # Save models
         self.ref_model.cfg.save(save_dir / "ref_model_config.json")
         torch.save(self.ref_model.state_dict(), save_dir / "ref_model.pt")
         self.model.cfg.save(save_dir / "model_config.json")
         torch.save(self.model.state_dict(), save_dir / "model.pt")
-        self.best_model.cfg.save(save_dir / "best_model_config.json")
-        torch.save(self.best_model.state_dict(), save_dir / "best_model.pt")
 
         # Save trainer
         self.cfg.save(save_dir / "trainer_config.json")
@@ -198,7 +195,7 @@ class Trainer:
             model.load_state_dict(state_dict)
             return model
 
-        # Load models (ref, current, best)
+        # Load models
         ref_model = load_model_ckpt(
             model_cfg_path=(load_dir / "ref_model_config.json"),
             model_state_path=(load_dir / "ref_model.pt"),
@@ -211,17 +208,10 @@ class Trainer:
             model_state_path=(load_dir / "model.pt"),
             device=device
         )
-        best_model = load_model_ckpt(
-            model_cfg_path=(load_dir / "best_model_config.json"),
-            model_state_path=(load_dir / "best_model.pt"),
-            device=device
-        )
-        for param in best_model.parameters():
-            param.requires_grad = False
 
         # Load trainer
         trainer_cfg = TrainerConfig.load(load_dir / "trainer_config.json")
-        trainer = Trainer(trainer_cfg, ref_model, model, best_model, device)
+        trainer = Trainer(trainer_cfg, ref_model, model, device)
         trainer_state = torch.load(load_dir / "trainer.pt", map_location=device)
         trainer.load_state_dict(trainer_state)
 
@@ -252,8 +242,6 @@ class Trainer:
                     with torch.no_grad():
                         states = move_to(states, self.ref_model.device)
                         ref_probs, _ = self.ref_model.predict(states, alpha, temp)
-                        states = move_to(states, self.best_model.device)
-                        best_probs, _ = self.best_model.predict(states, alpha, temp)
                 
                 # Increment loss
                 states = move_to(states, self.device)
@@ -261,14 +249,13 @@ class Trainer:
                 responses = self._float32_tree(move_to(responses, self.device))
                 probs = self._float32_tree(move_to(probs, self.device))
                 ref_probs = self._float32_tree(move_to(ref_probs, self.device))
-                best_probs = self._float32_tree(move_to(best_probs, self.device))
                 batch_loss, batch_loss_components = self.loss.inc_loss(
-                    states, actions, responses, probs, ref_probs, best_probs
+                    states, actions, responses, probs, ref_probs
                 )
 
                 # Measure grad norms
                 if measure_grad_norms:
-                    self.loss.measure_grad_norms(self.model, states, actions, responses, probs, ref_probs, best_probs, alpha, temp)
+                    self.loss.measure_grad_norms(self.model, states, actions, responses, probs, ref_probs, alpha, temp)
                 return batch_loss, batch_loss_components
             except RuntimeError as e:
                 if attempt < self.cfg.max_batch_attempts:
@@ -296,8 +283,6 @@ class Trainer:
             with torch.no_grad():
                 states = move_to(states, self.ref_model.device)
                 ref_probs, _ = self.ref_model.predict(states, alpha, temp)
-                states = move_to(states, self.best_model.device)
-                best_probs, _ = self.best_model.predict(states, alpha, temp)
         
         # Measure grad norms
         states = move_to(states, self.device)
@@ -305,8 +290,7 @@ class Trainer:
         responses = self._float32_tree(move_to(responses, self.device))
         probs = self._float32_tree(move_to(probs, self.device))
         ref_probs = self._float32_tree(move_to(ref_probs, self.device))
-        best_probs = self._float32_tree(move_to(best_probs, self.device))
-        self.loss.measure_grad_norms(self.model, states, actions, responses, probs, ref_probs, best_probs)
+        self.loss.measure_grad_norms(self.model, states, actions, responses, probs, ref_probs)
 
     def _loop_without_grad(self, loader, desc, alpha=None, temp=None):
         self.loss.init_cumulative_loss()
@@ -374,9 +358,10 @@ class Trainer:
         test_loss, test_loss_components = self._loop_without_grad(loader=test_loader, desc="Evaluating", alpha=0.0, temp=1.0)
         self.logger.log(
             f"[Epoch {epoch}][Eval] Accuracy: {test_acc:.4f} | Avg Guesses: {test_avg_guesses:.4f} | "
-            f"Actor Loss: {test_loss_components['actor']:.6f} | Critic Loss: {test_loss_components['critic']:.6f} | "
-            f"Entropy Loss: {test_loss_components['entropy']:.6f} | KL Reg Loss: {test_loss_components['kl_reg']:.6f} | "
-            f"KL Guide Loss: {test_loss_components['kl_guide']:.6f} | KL Best Loss: {test_loss_components['kl_best']:.6f} "
+            f"Search KL: {test_loss_components['search_kl']:.6f} | Entropy Loss: {test_loss_components['entropy']:.6f} | "
+            f"KL Reg Loss: {test_loss_components['kl_reg']:.6f} | KL Guide Loss: {test_loss_components['kl_guide']:.6f} | "
+            f"Search Cosine: {test_loss_components['search_cosine']:.6f} | "
+            f"Unique States: {test_loss_components['unique_state_pct']:.2f}%"
         )
         # Explicitly cleanup eval objects (prevents OOM and semaphore leaks)
         del test_loader; del test_dataset; del test_episodes; gc.collect()
@@ -414,10 +399,10 @@ class Trainer:
             desc = f"Rollout {i}"
             rollout_loss, rollout_loss_components = self._loop_with_grad(loader=processing_loader, desc=desc)
             self.logger.log(
-                f"[Epoch {epoch}][{desc}] Loss: {rollout_loss:.6f} | Actor Loss: {rollout_loss_components['actor']:.6f} | "
-                f"Critic Loss: {rollout_loss_components['critic']:.6f} | Entropy Loss: {rollout_loss_components['entropy']:.6f} | "
-                f"KL Reg Loss: {rollout_loss_components['kl_reg']:.6f} | KL Guide Loss: {rollout_loss_components['kl_guide']:.6f} | "
-                f"KL Best Loss: {rollout_loss_components['kl_best']:.6f}"
+                f"[Epoch {epoch}][{desc}] Loss: {rollout_loss:.6f} | Search KL: {rollout_loss_components['search_kl']:.6f} | "
+                f"Entropy Loss: {rollout_loss_components['entropy']:.6f} | KL Reg Loss: {rollout_loss_components['kl_reg']:.6f} | "
+                f"KL Guide Loss: {rollout_loss_components['kl_guide']:.6f} | Search Cosine: {rollout_loss_components['search_cosine']:.6f} | "
+                f"Unique States: {rollout_loss_components['unique_state_pct']:.2f}%"
             )
         # Explicitly cleanup the rollout objects (prevents OOM and semaphore leaks)
         del processing_loader; del rollout_dataset; del rollout_episodes; gc.collect()
@@ -444,7 +429,7 @@ class Trainer:
         while self.last_epoch < end_epoch:
             epoch = self.last_epoch + 1
 
-            # Update ref model
+            # Update KL reference model
             self.ref_model.load_state_dict(self.model.state_dict())
 
             # Run epoch
@@ -459,15 +444,14 @@ class Trainer:
 
             # Best model checkpointing
             if self.cfg.checkpoint_dir:
-                new_best_model = (
+                new_best_checkpoint = (
                     test_acc > self.best_accuracy or
                     test_acc == self.best_accuracy and test_guesses < self.best_avg_guesses
                 )
-                if new_best_model:
+                if new_best_checkpoint:
                     self.best_accuracy = test_acc
                     self.best_avg_guesses = test_guesses
                     self.save_checkpoint(epoch)
-                    self.best_model.load_state_dict(self.model.state_dict())
 
             # Increment epoch
             self.last_epoch = epoch


### PR DESCRIPTION
### Motivation

- Replace the previous actor-critic style training and advantage machinery with a search-distillation workflow that scores candidate first-actions via full rollouts and distills the resulting search distribution into the model. 
- Reduce OOM / memory blowups by avoiding unnecessary m-way expansions during normal episode collection and by sampling/searching only when building distillation targets. 
- Simplify trainer bookkeeping by removing the unused `best_model` path and aligning scheduler/loss metrics to the new objective.

### Description

- Reworked `Simulator` to support search-based rollouts by adding `num_search_actions`, `_sample_action_indices`, `_rollout_scores`, `search_actions`, `build_search_targets_for_states`, and `unique_state_pct`, and changed `step` to accept `calculate_reward` to skip reward computation during episode collection. 
- Modified episode collection so `collect_episodes_mb` does not compute rewards or expand states over sampled hidden targets, and introduced `build_search_targets_for_states` to construct search-distillation targets from collected states. 
- Replaced the RL loss in `wordle/train/loss.py` with a search-distillation objective: compute `search_kl` between search targets and the model's masked policy, add entropy regularization, `kl_reg`, `kl_guide`, and report `search_cosine` and `unique_state_pct`; removed actor/critic/advantage/GAE code. 
- Updated `Trainer` to remove `best_model` handling, adapt checkpoint saving/loading, use the new simulator/loss outputs, and update logging to the new loss keys. 
- Adjusted scheduler to track `search_kl` as the primary improvement metric. 
- Updated entry scripts and inference utilities (`experiments/run_full/run_new.py`, `wordle/train/inference.py`) to new simulator params and simplified model setup.

### Testing

- Performed import and basic integration smoke checks to ensure the codebase loads after refactor, which completed without runtime import errors. 
- Executed a short local smoke training run using `experiments/run_full/run_new.py` with minimal/short settings to validate end-to-end flow (collection -> build search targets -> loss computation), which succeeded without runtime exceptions. 
- Ran `wordle.train.inference.inference` on a small batch to validate collection and argmax evaluation paths, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b10d40c4c832992bada433f8344ac)